### PR TITLE
Backporting to 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: node_js
 after_success:
   - test $TRAVIS_NODE_VERSION = '4.3' && npm run coverage && npm install coveralls@2 && npm run coveralls
 node_js:
+  - "0.10"
   - "0.12"
   - "4.1"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Requirements
 ============
 
 * Async - Node.js 0.10 / 0.12 / IO.js
-* Sync - Node.js 0.12 / IO.js
+* Sync - Node.js 0.12 / IO.js (0.10 with [node-zlib-backport](https://www.npmjs.com/package/node-zlib-backport) dependency)
 
 Comparison Table
 ================

--- a/lib/packer-sync.js
+++ b/lib/packer-sync.js
@@ -1,6 +1,10 @@
 'use strict';
 
-var zlib = require('node-zlib-backport');
+var zlib = require('zlib');
+if (!zlib.deflateSync) {
+  // Backwards compatibility with 0.10.
+  zlib = require('node-zlib-backport');
+}
 var constants = require('./constants');
 var Packer = require('./packer');
 

--- a/lib/packer-sync.js
+++ b/lib/packer-sync.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var zlib = require('zlib');
+var zlib = require('node-zlib-backport');
 var constants = require('./constants');
 var Packer = require('./packer');
 

--- a/lib/parser-sync.js
+++ b/lib/parser-sync.js
@@ -1,7 +1,10 @@
 'use strict';
 
-
-var zlib = require('node-zlib-backport');
+var zlib = require('zlib');
+if (!zlib.inflateSync) {
+  // Backwards compatibility with 0.10.
+  zlib = require('node-zlib-backport');
+}
 var SyncReader = require('./sync-reader');
 var FilterSync = require('./filter-parse-sync');
 var Parser = require('./parser');

--- a/lib/parser-sync.js
+++ b/lib/parser-sync.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-var zlib = require('zlib');
+var zlib = require('node-zlib-backport');
 var SyncReader = require('./sync-reader');
 var FilterSync = require('./filter-parse-sync');
 var Parser = require('./parser');

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "bugs": {
     "url": "https://github.com/lukeapage/pngjs2/issues"
   },
-  "dependencies": {
+  "optionalDependencies": {
     "node-zlib-backport": "^0.11.15"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
   "bugs": {
     "url": "https://github.com/lukeapage/pngjs2/issues"
   },
+  "dependencies": {
+    "node-zlib-backport": "^0.11.15"
+  },
   "devDependencies": {
     "buffer-equal": "1.0.0",
     "connect": "^3.4.0",


### PR DESCRIPTION
This backports this library for sync interface to node 0.10 for compatibility with Meteor which is still on node.js 0.10.