### PR TITLE
fix: explicitly coerce all pixel-dimensioned inputs to integers

### DIFF
--- a/lib/png.js
+++ b/lib/png.js
@@ -12,8 +12,9 @@ var PNG = exports.PNG = function(options) {
 
   options = options || {}; // eslint-disable-line no-param-reassign
 
-  this.width = options.width || 0;
-  this.height = options.height || 0;
+  // coerce pixel dimensions to integers (also coerces undefined -> 0):
+  this.width = options.width | 0;
+  this.height = options.height | 0;
 
   this.data = this.width > 0 && this.height > 0 ?
     new Buffer(4 * this.width * this.height) : null;
@@ -116,6 +117,15 @@ PNG.prototype._handleClose = function() {
 
 
 PNG.bitblt = function(src, dst, srcX, srcY, width, height, deltaX, deltaY) { // eslint-disable-line max-params
+  // coerce pixel dimensions to integers (also coerces undefined -> 0):
+  /* eslint-disable no-param-reassign */
+  srcX |= 0;
+  srcY |= 0;
+  width |= 0;
+  height |= 0;
+  deltaX |= 0;
+  deltaY |= 0;
+  /* eslint-enable no-param-reassign */
 
   if (srcX > src.width || srcY > src.height || srcX + width > src.width || srcY + height > src.height) {
     throw new Error('bitblt reading outside image');


### PR DESCRIPTION
I was using pngjs to extract element screenshots for an acceptance tests and couldn't figure out why they weren't lining up horizontally. Turns out that I was feeding `PNG.bitblt` fractional values for `srcY` (e.g. 671.92), which when multiplied by `src.width` advances the starting index for the buffer copy by the fractional part times the width of the output region:

``` js
  for (var y = 0; y < height; y++) {
    src.data.copy(dst.data,
      ((deltaY + y) * dst.width + deltaX) << 2,
      ((srcY + y) * src.width + srcX) << 2,
      ((srcY + y) * src.width + srcX + width) << 2
    );
  }
```

This PR uses bitwise-or to coerce all the pixel-dimensioned `bitblt` arguments (as well as the width/height options to the `PNG()` constructor) to integers.
