### PR TITLE
Remove zlib for browserify and Node ^9.0.0

### DIFF
--- a/lib/packer-sync.js
+++ b/lib/packer-sync.js
@@ -2,6 +2,9 @@
 
 var hasSyncZlib = true;
 var zlib = require('zlib');
+if (!zlib.deflateSync) {
+  hasSyncZlib = false;
+}
 var constants = require('./constants');
 var Packer = require('./packer');
 

--- a/lib/parser-sync.js
+++ b/lib/parser-sync.js
@@ -3,6 +3,9 @@
 var hasSyncZlib = true;
 var zlib = require('zlib');
 var inflateSync = require('./sync-inflate');
+if (!zlib.deflateSync) {
+  hasSyncZlib = false;
+}
 var SyncReader = require('./sync-reader');
 var FilterSync = require('./filter-parse-sync');
 var Parser = require('./parser');


### PR DESCRIPTION
The zlib backfill prevents using this package in browserify or in node 9.x.

Relevant to another issue here:
https://github.com/americanexpress/jest-image-snapshot/issues/31