### PR TITLE
Return a correct alpha value in the metadata callback when a tRNS chunk is present

### DIFF
--- a/lib/parser-async.js
+++ b/lib/parser-async.js
@@ -19,7 +19,8 @@ var ParserAsync = module.exports = function(options) {
     palette: this._handlePalette.bind(this),
     transColor: this._handleTransColor.bind(this),
     finished: this._finished.bind(this),
-    inflateData: this._inflateData.bind(this)
+    inflateData: this._inflateData.bind(this),
+    simpleTransparency: this._simpleTransparency.bind(this)
   });
   this._options = options;
   this.writable = true;
@@ -101,9 +102,7 @@ ParserAsync.prototype._inflateData = function(data) {
 };
 
 ParserAsync.prototype._handleMetaData = function(metaData) {
-
-  this.emit('metadata', metaData);
-
+  this._metaData = metaData;
   this._bitmapInfo = Object.create(metaData);
 
   this._filter = new FilterAsync(this._bitmapInfo);
@@ -117,8 +116,15 @@ ParserAsync.prototype._handlePalette = function(palette) {
   this._bitmapInfo.palette = palette;
 };
 
+ParserAsync.prototype._simpleTransparency = function() {
+  this._metaData.alpha = true;
+};
 
 ParserAsync.prototype._finished = function() {
+  // Up until this point, we don't know if we have a tRNS chunk (alpha)
+  // so we can't emit metadata any earlier
+  this.emit('metadata', this._metaData);
+
   if (this.errord) {
     return;
   }

--- a/lib/parser-async.js
+++ b/lib/parser-async.js
@@ -20,7 +20,8 @@ var ParserAsync = module.exports = function(options) {
     transColor: this._handleTransColor.bind(this),
     finished: this._finished.bind(this),
     inflateData: this._inflateData.bind(this),
-    simpleTransparency: this._simpleTransparency.bind(this)
+    simpleTransparency: this._simpleTransparency.bind(this),
+    headersFinished: this._headersFinished.bind(this)
   });
   this._options = options;
   this.writable = true;
@@ -120,11 +121,13 @@ ParserAsync.prototype._simpleTransparency = function() {
   this._metaData.alpha = true;
 };
 
-ParserAsync.prototype._finished = function() {
+ParserAsync.prototype._headersFinished = function() {
   // Up until this point, we don't know if we have a tRNS chunk (alpha)
   // so we can't emit metadata any earlier
   this.emit('metadata', this._metaData);
+};
 
+ParserAsync.prototype._finished = function() {
   if (this.errord) {
     return;
   }

--- a/lib/parser-sync.js
+++ b/lib/parser-sync.js
@@ -37,6 +37,10 @@ module.exports = function(buffer, options) {
     metaData.palette = palette;
   }
 
+  function handleSimpleTransparency() {
+    metaData.alpha = true;
+  }
+
   var gamma;
   function handleGamma(_gamma_) {
     gamma = _gamma_;
@@ -56,7 +60,8 @@ module.exports = function(buffer, options) {
     gamma: handleGamma,
     palette: handlePalette,
     transColor: handleTransColor,
-    inflateData: handleInflateData
+    inflateData: handleInflateData,
+    simpleTransparency: handleSimpleTransparency
   });
 
   parser.start();

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -33,6 +33,7 @@ var Parser = module.exports = function(options, dependencies) {
   this.parsed = dependencies.parsed;
   this.inflateData = dependencies.inflateData;
   this.finished = dependencies.finished;
+  this.simpleTransparency = dependencies.simpleTransparency;
 };
 
 Parser.prototype.start = function() {
@@ -205,6 +206,7 @@ Parser.prototype._parsePLTE = function(data) {
 };
 
 Parser.prototype._handleTRNS = function(length) {
+  this.simpleTransparency();
   this.read(length, this._parseTRNS.bind(this));
 };
 Parser.prototype._parseTRNS = function(data) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -11,6 +11,7 @@ var Parser = module.exports = function(options, dependencies) {
 
   this._hasIHDR = false;
   this._hasIEND = false;
+  this._emittedHeadersFinished = false;
 
   // input flags/metadata
   this._palette = [];
@@ -34,6 +35,7 @@ var Parser = module.exports = function(options, dependencies) {
   this.inflateData = dependencies.inflateData;
   this.finished = dependencies.finished;
   this.simpleTransparency = dependencies.simpleTransparency;
+  this.headersFinished = dependencies.headersFinished || function(){};
 };
 
 Parser.prototype.start = function() {
@@ -254,6 +256,10 @@ Parser.prototype._parseGAMA = function(data) {
 };
 
 Parser.prototype._handleIDAT = function(length) {
+  if (!this._emittedHeadersFinished) {
+    this._emittedHeadersFinished = true;
+    this.headersFinished();
+  }
   this.read(-length, this._parseIDAT.bind(this, length));
 };
 Parser.prototype._parseIDAT = function(length, data) {

--- a/test/png-parse-spec.js
+++ b/test/png-parse-spec.js
@@ -319,3 +319,12 @@ test("should return an error if a PNG is normal except for a missing IEND", func
     t.end();
   });
 });
+
+test("should set alpha=true in metadata for images with TRNS chunk", function (t) {
+  fs.createReadStream(path.join(__dirname, "in", "tbbn0g04.png"))
+    .pipe(new PNG())
+    .on('metadata', function (metadata) {
+      t.ok(metadata.alpha, "Image should have alpha=true");
+      t.end();
+    });
+});

--- a/test/png-parse-spec.js
+++ b/test/png-parse-spec.js
@@ -320,7 +320,7 @@ test("should return an error if a PNG is normal except for a missing IEND", func
   });
 });
 
-test("should set alpha=true in metadata for images with TRNS chunk", function (t) {
+test("should set alpha=true in metadata for images with tRNS chunk", function (t) {
   fs.createReadStream(path.join(__dirname, "in", "tbbn0g04.png"))
     .pipe(new PNG())
     .on('metadata', function (metadata) {


### PR DESCRIPTION
Previously metadata showed alpha=false even if a tRNS chunk was there, which was misleading. Delayed the metadata event until the first IDAT chunk to check for the presence of tRNS chunks to return correct metadata.