### PR TITLE
Fix #129

### DIFF
--- a/lib/parser-async.js
+++ b/lib/parser-async.js
@@ -140,7 +140,6 @@ ParserAsync.prototype._finished = function() {
     // no more data to inflate
     this._inflate.end();
   }
-  this.destroySoon();
 };
 
 ParserAsync.prototype._complete = function(filteredData) {

--- a/test/png-parse-spec.js
+++ b/test/png-parse-spec.js
@@ -346,3 +346,15 @@ test("should set alpha=true in metadata for images with tRNS chunk", function (t
       t.end();
     });
 });
+
+test("Should parse with low highWaterMark", function (t) {
+  fs.createReadStream(path.join(__dirname, "in", "tbbn0g04.png"), { highWaterMark: 2 })
+    .pipe(new PNG())
+    .on('parsed', function () {
+      t.pass("Image should have parsed");
+      t.end();
+    })
+    .on('error', function (e) {
+      t.error(e, "Should not error");
+    });
+});


### PR DESCRIPTION
When `destroySoon` is called from `_finished`, print logging shows that `end` and `_end` are called before input read stream actually emits `end`, which eventually results in an error due to unread partial `fileCrc` is still in buffer.

From testing, normal input stream will call `_end` when it terminates without extra call to `destroySoon`. Added an extra test case for #129 