### PR TITLE
fix(buffer): migrate to safe constructor methods

### DIFF
--- a/examples/16bit_write.js
+++ b/examples/16bit_write.js
@@ -6,7 +6,7 @@ var w = 32;
 var h = 64;
 
 /// RGBA input (color type 6)
-var buffer = new Buffer(2 * w * h * 4);
+var buffer = Buffer.alloc(2 * w * h * 4);
 var bitmap = new Uint16Array(buffer.buffer);
 for (var i = 0; i < h; i++) {
   for (var j = 0; j < w; j++) {
@@ -31,7 +31,7 @@ png.pack().pipe(fs.createWriteStream('colortype6.png'));
 
 //////// Grayscale 16 bits///////
 
-var buffer = new Buffer(2 * w * h);
+var buffer = Buffer.alloc(2 * w * h);
 var bitmap = new Uint16Array(buffer.buffer);
 for (var i = 0; i < h; i++) {
   for (var j = 0; j < w; j++)

--- a/examples/set-colortype.js
+++ b/examples/set-colortype.js
@@ -3,7 +3,7 @@ var PNG = require("../lib/png").PNG;
 var w = 320;
 var h = 200;
 
-var bitmapWithoutAlpha = new Buffer(w * h * 3);
+var bitmapWithoutAlpha = Buffer.alloc(w * h * 3);
 var ofs=0;
 for (var i = 0; i < bitmapWithoutAlpha.length; i+=3) {
     bitmapWithoutAlpha[ofs++] = 0xff;

--- a/lib/bitmapper.js
+++ b/lib/bitmapper.js
@@ -211,7 +211,7 @@ exports.dataToBitMap = function(data, bitmapInfo) {
   }
   var pxData;
   if (depth <= 8) {
-    pxData = new Buffer(width * height * 4);
+    pxData = Buffer.alloc(width * height * 4);
   }
   else {
     pxData = new Uint16Array(width * height * 4);

--- a/lib/bitpacker.js
+++ b/lib/bitpacker.js
@@ -30,7 +30,7 @@ module.exports = function(dataIn, width, height, options) {
     maxValue = 65535;
     outBpp *= 2;
   }
-  var outData = new Buffer(width * height * outBpp);
+  var outData = Buffer.alloc(width * height * outBpp);
 
   var inIndex = 0;
   var outIndex = 0;

--- a/lib/chunkstream.js
+++ b/lib/chunkstream.js
@@ -52,7 +52,7 @@ ChunkStream.prototype.write = function(data, encoding) {
     dataBuffer = data;
   }
   else {
-    dataBuffer = new Buffer(data, encoding || this._encoding);
+    dataBuffer = Buffer.from(data, encoding || this._encoding);
   }
 
   this._buffers.push(dataBuffer);
@@ -147,7 +147,7 @@ ChunkStream.prototype._processRead = function(read) {
 
   var pos = 0;
   var count = 0;
-  var data = new Buffer(read.length);
+  var data = Buffer.alloc(read.length);
 
   // create buffer for all data
   while (pos < read.length) {

--- a/lib/filter-pack.js
+++ b/lib/filter-pack.js
@@ -161,7 +161,7 @@ module.exports = function(pxData, width, height, options, bpp) {
   var byteWidth = width * bpp;
   var rawPos = 0;
   var pxPos = 0;
-  var rawData = new Buffer((byteWidth + 1) * height);
+  var rawData = Buffer.alloc((byteWidth + 1) * height);
 
   var sel = filterTypes[0];
 

--- a/lib/filter-parse.js
+++ b/lib/filter-parse.js
@@ -128,7 +128,7 @@ Filter.prototype._reverseFilterLine = function(rawData) {
   }
   else {
 
-    unfilteredLine = new Buffer(byteWidth);
+    unfilteredLine = Buffer.alloc(byteWidth);
 
     switch (filter) {
       case 1:

--- a/lib/format-normaliser.js
+++ b/lib/format-normaliser.js
@@ -80,7 +80,7 @@ module.exports = function(indata, imageData) {
     if (depth !== 8) {
       // if we need to change the buffer size
       if (depth === 16) {
-        outdata = new Buffer(width * height * 4);
+        outdata = Buffer.alloc(width * height * 4);
       }
       scaleDepth(indata, outdata, width, height, depth);
     }

--- a/lib/packer-async.js
+++ b/lib/packer-async.js
@@ -20,7 +20,7 @@ util.inherits(PackerAsync, Stream);
 
 PackerAsync.prototype.pack = function(data, width, height, gamma) {
   // Signature
-  this.emit('data', new Buffer(constants.PNG_SIGNATURE));
+  this.emit('data', Buffer.from(constants.PNG_SIGNATURE));
   this.emit('data', this._packer.packIHDR(width, height));
 
   if (gamma) {

--- a/lib/packer-sync.js
+++ b/lib/packer-sync.js
@@ -21,7 +21,7 @@ module.exports = function(metaData, opt) {
   var chunks = [];
 
   // Signature
-  chunks.push(new Buffer(constants.PNG_SIGNATURE));
+  chunks.push(Buffer.from(constants.PNG_SIGNATURE));
 
   // Header
   chunks.push(packer.packIHDR(metaData.width, metaData.height));

--- a/lib/packer.js
+++ b/lib/packer.js
@@ -65,7 +65,7 @@ Packer.prototype.filterData = function(data, width, height) {
 Packer.prototype._packChunk = function(type, data) {
 
   var len = (data ? data.length : 0);
-  var buf = new Buffer(len + 12);
+  var buf = Buffer.alloc(len + 12);
 
   buf.writeUInt32BE(len, 0);
   buf.writeUInt32BE(type, 4);
@@ -79,14 +79,14 @@ Packer.prototype._packChunk = function(type, data) {
 };
 
 Packer.prototype.packGAMA = function(gamma) {
-  var buf = new Buffer(4);
+  var buf = Buffer.alloc(4);
   buf.writeUInt32BE(Math.floor(gamma * constants.GAMMA_DIVISION), 0);
   return this._packChunk(constants.TYPE_gAMA, buf);
 };
 
 Packer.prototype.packIHDR = function(width, height) {
 
-  var buf = new Buffer(13);
+  var buf = Buffer.alloc(13);
   buf.writeUInt32BE(width, 0);
   buf.writeUInt32BE(height, 4);
   buf[8] = this._options.bitDepth; // Bit depth

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -82,7 +82,7 @@ Parser.prototype._parseChunkBegin = function(data) {
   }
 
   this._crc = new CrcCalculator();
-  this._crc.write(new Buffer(name));
+  this._crc.write(Buffer.from(name));
 
   if (this._chunks[type]) {
     return this._chunks[type](length);

--- a/lib/png.js
+++ b/lib/png.js
@@ -17,7 +17,7 @@ var PNG = exports.PNG = function(options) {
   this.height = options.height | 0;
 
   this.data = this.width > 0 && this.height > 0 ?
-    new Buffer(4 * this.width * this.height) : null;
+    Buffer.alloc(4 * this.width * this.height) : null;
 
   if (options.fill && this.data) {
     this.data.fill(0);

--- a/test/imagediff.js
+++ b/test/imagediff.js
@@ -355,7 +355,7 @@
     callback = callback || Function;
 
     base64Data = canvas.toDataURL().replace(/^data:image\/\w+;base64,/,"");
-    decodedImage = new Buffer(base64Data, 'base64');
+    decodedImage = Buffer.from(base64Data, 'base64');
     require('fs').writeFile(outputFile, decodedImage, callback);
   }
 

--- a/test/png-parse-spec.js
+++ b/test/png-parse-spec.js
@@ -303,7 +303,7 @@ test("should correctly support crazily-filtered images", function (t) {
 });
 
 test("should bail with an error given an invalid PNG", function (t) {
-  var buf = new Buffer("I AM NOT ACTUALLY A PNG", "utf8")
+  var buf = Buffer.from("I AM NOT ACTUALLY A PNG", "utf8")
 
   return parseBuffer(buf, function (err) {
     t.ok(err instanceof Error, "Error should be received");
@@ -312,7 +312,7 @@ test("should bail with an error given an invalid PNG", function (t) {
 })
 
 test("should bail with an error given an empty file", function (t) {
-  var buf = new Buffer("")
+  var buf = Buffer.from("")
 
   return parseBuffer(buf, function (err) {
     t.ok(err instanceof Error, "Error should be received");
@@ -321,7 +321,7 @@ test("should bail with an error given an empty file", function (t) {
 })
 
 test("should bail with an error given a truncated PNG", function (t) {
-  var buf = new Buffer("89504e470d0a1a0a000000", "hex")
+  var buf = Buffer.from("89504e470d0a1a0a000000", "hex")
 
   return parseBuffer(buf, function (err) {
     t.ok(err instanceof Error, "Error should be received");
@@ -330,7 +330,7 @@ test("should bail with an error given a truncated PNG", function (t) {
 })
 
 test("should return an error if a PNG is normal except for a missing IEND", function (t) {
-  var buf = new Buffer("89504e470d0a1a0a0000000d49484452000000100000001008000000003a98a0bd000000017352474200aece1ce90000002174455874536f6674776172650047726170686963436f6e7665727465722028496e74656c297787fa190000008849444154789c448e4111c020100363010b58c00216b080052c60010b58c0c259c00216ae4d3b69df99dd0d1062caa5b63ee6b27d1c012996dceae86b6ef38398106acb65ae3e8edbbef780564b5e73743fdb409e1ef2f4803c3de4e901797ac8d3f3f0f490a7077ffffd03f5f507eaeb0fd4d71fa8af3f505f7fa0befe7c7dfdb9000000ffff0300c0fd7f8179301408", "hex")
+  var buf = Buffer.from("89504e470d0a1a0a0000000d49484452000000100000001008000000003a98a0bd000000017352474200aece1ce90000002174455874536f6674776172650047726170686963436f6e7665727465722028496e74656c297787fa190000008849444154789c448e4111c020100363010b58c00216b080052c60010b58c0c259c00216ae4d3b69df99dd0d1062caa5b63ee6b27d1c012996dceae86b6ef38398106acb65ae3e8edbbef780564b5e73743fdb409e1ef2f4803c3de4e901797ac8d3f3f0f490a7077ffffd03f5f507eaeb0fd4d71fa8af3f505f7fa0befe7c7dfdb9000000ffff0300c0fd7f8179301408", "hex")
 
   return parseBuffer(buf, function (err) {
     t.ok(err instanceof Error, "Error should be received");


### PR DESCRIPTION
Hey Luke,

I've been using this library in a project, and ended up needing the updated Buffer constructors (per https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/ ). I thought it might help more than just me, so I thought it best to run past you. 

Thanks for the great work!
Zack