### PR TITLE
fixes error when trying to access this._reads in chunkstream.js

### DIFF
--- a/lib/chunkstream.js
+++ b/lib/chunkstream.js
@@ -29,7 +29,7 @@ ChunkStream.prototype.read = function (length, callback) {
       this._process();
 
       // its paused and there is not enought data then ask for more
-      if (this._paused && this._reads.length > 0) {
+      if (this._paused && this._reads && this._reads.length > 0) {
         this._paused = false;
 
         this.emit("drain");


### PR DESCRIPTION
Hello!

Thank you for the good work you do with pngjs!

I am using pngjs in [assistive-webdriver](https://github.com/AmadeusITGroup/Assistive-Webdriver) and when trying to update from version 3.4.0 to 4.0.0 (cf [this PR](https://github.com/AmadeusITGroup/Assistive-Webdriver/pull/62), my tests started to fail with `TypeError: Cannot read property 'length' of null` at [line 35 (in version 4.0.0) of `chunkstream.js`](https://github.com/lukeapage/pngjs/blob/31bedc7bb07820507513c6db87053cd59ce9fae8/lib/chunkstream.js#L35).

So, I am suggesting this fix, because, as far as I understand, it is possible that `_reads` becomes `null` between line 25 and line 35 because there is some asynchronous delay added by `process.nextTick` and also because `this._process()` (that is called line 32) may call `this._end()` (line 203) which calls `this.destroy()` which sets `null` in `this._reads`.

Do you think it is the right fix?

Thank you in advance!