### PR TITLE
adding skipRescale option

### DIFF
--- a/lib/format-normaliser.js
+++ b/lib/format-normaliser.js
@@ -63,7 +63,7 @@ function scaleDepth(indata, outdata, width, height, depth) {
   }
 }
 
-module.exports = function (indata, imageData) {
+module.exports = function (indata, imageData, skipRescale = false) {
   let depth = imageData.depth;
   let width = imageData.width;
   let height = imageData.height;
@@ -81,7 +81,7 @@ module.exports = function (indata, imageData) {
       replaceTransparentColor(indata, outdata, width, height, transColor);
     }
     // if it needs scaling
-    if (depth !== 8) {
+    if (depth !== 8 && !skipRescale) {
       // if we need to change the buffer size
       if (depth === 16) {
         outdata = Buffer.alloc(width * height * 4);

--- a/lib/parser-async.js
+++ b/lib/parser-async.js
@@ -154,7 +154,7 @@ ParserAsync.prototype._complete = function (filteredData) {
   try {
     let bitmapData = bitmapper.dataToBitMap(filteredData, this._bitmapInfo);
 
-    normalisedBitmapData = formatNormaliser(bitmapData, this._bitmapInfo);
+    normalisedBitmapData = formatNormaliser(bitmapData, this._bitmapInfo, this._options.skipRescale);
     bitmapData = null;
   } catch (ex) {
     this._handleError(ex);

--- a/lib/parser-async.js
+++ b/lib/parser-async.js
@@ -154,7 +154,11 @@ ParserAsync.prototype._complete = function (filteredData) {
   try {
     let bitmapData = bitmapper.dataToBitMap(filteredData, this._bitmapInfo);
 
-    normalisedBitmapData = formatNormaliser(bitmapData, this._bitmapInfo, this._options.skipRescale);
+    normalisedBitmapData = formatNormaliser(
+      bitmapData,
+      this._bitmapInfo,
+      this._options.skipRescale
+    );
     bitmapData = null;
   } catch (ex) {
     this._handleError(ex);

--- a/lib/parser-sync.js
+++ b/lib/parser-sync.js
@@ -99,7 +99,11 @@ module.exports = function (buffer, options) {
   let bitmapData = bitmapper.dataToBitMap(unfilteredData, metaData);
   unfilteredData = null;
 
-  let normalisedBitmapData = formatNormaliser(bitmapData, metaData, options.skipRescale);
+  let normalisedBitmapData = formatNormaliser(
+    bitmapData,
+    metaData,
+    options.skipRescale
+  );
 
   metaData.data = normalisedBitmapData;
   metaData.gamma = gamma || 0;

--- a/lib/parser-sync.js
+++ b/lib/parser-sync.js
@@ -99,7 +99,7 @@ module.exports = function (buffer, options) {
   let bitmapData = bitmapper.dataToBitMap(unfilteredData, metaData);
   unfilteredData = null;
 
-  let normalisedBitmapData = formatNormaliser(bitmapData, metaData);
+  let normalisedBitmapData = formatNormaliser(bitmapData, metaData, options.skipRescale);
 
   metaData.data = normalisedBitmapData;
   metaData.gamma = gamma || 0;


### PR DESCRIPTION
It would be very useful if pngjs had an option to read non-8bit depth png files and preserve all bits without rescaling.  Example, reading 16bit png.

Issue #87 addressed this, but the solution by @gforge was implemented in his own https://github.com/gforge/pngjs3.

This pull request adds the `skipRescale` option to preserve the bit depth of the input file,  based on the @gforge solution.