### PR TITLE
Unswallow two errors in sync-reader

### DIFF
--- a/lib/sync-reader.js
+++ b/lib/sync-reader.js
@@ -36,10 +36,10 @@ SyncReader.prototype.process = function () {
   }
 
   if (this._reads.length > 0) {
-    return new Error("There are some read requests waitng on finished stream");
+    throw new Error("There are some read requests waitng on finished stream");
   }
 
   if (this._buffer.length > 0) {
-    return new Error("unrecognised content at end of stream");
+    throw new Error("unrecognised content at end of stream");
   }
 };


### PR DESCRIPTION
I had a file with a chunk length that was longer than the rest of the buffer. It wasn't being rejected like it should.

The `reader.process()` call in parser-sync.js isn't using the return value, so returning the errors in sync-reader will mean that they are just swallowed and not reported to the user. I've changed it so that they are properly thrown instead.