### PR TITLE
[Feature] Export PNG with multiple DAT chunks

### DIFF
--- a/lib/packer-async.js
+++ b/lib/packer-async.js
@@ -34,7 +34,9 @@ PackerAsync.prototype.pack = function (data, width, height, gamma) {
   this._deflate.on(
     "data",
     function (compressedData) {
-      this.emit("data", this._packer.packIDAT(compressedData));
+      this._packer.packIDATs(compressedData).forEach((buffer) => {
+        this.emit("data", buffer);
+      });
     }.bind(this)
   );
 

--- a/lib/packer-sync.js
+++ b/lib/packer-sync.js
@@ -47,7 +47,7 @@ module.exports = function (metaData, opt) {
   if (!compressedData || !compressedData.length) {
     throw new Error("bad png - invalid compressed data response");
   }
-  chunks.push(packer.packIDAT(compressedData));
+  chunks.push(...packer.packIDATs(compressedData));
 
   // End
   chunks.push(packer.packIEND());

--- a/lib/packer.js
+++ b/lib/packer.js
@@ -130,10 +130,19 @@ Packer.prototype.packIDATs = function (data) {
     return [this.packIDAT(data)];
   }
   let chunks = [];
-  let dataChunkAmount = Math.ceil(data.length / this._options.maximumDataChunkSize);
+  let dataChunkAmount = Math.ceil(
+    data.length / this._options.maximumDataChunkSize
+  );
   for (let i = 0; i < dataChunkAmount; i++) {
     let startIndex = i * this._options.maximumDataChunkSize;
-    chunks.push(this.packIDAT(data.subarray(startIndex, Math.min(data.length, startIndex + this._options.maximumDataChunkSize))));
+    chunks.push(
+      this.packIDAT(
+        data.subarray(
+          startIndex,
+          Math.min(data.length, startIndex + this._options.maximumDataChunkSize)
+        )
+      )
+    );
   }
   return chunks;
 };

--- a/lib/packer.js
+++ b/lib/packer.js
@@ -18,6 +18,7 @@ let Packer = (module.exports = function (options) {
     options.inputHasAlpha != null ? options.inputHasAlpha : true;
   options.deflateFactory = options.deflateFactory || zlib.createDeflate;
   options.bitDepth = options.bitDepth || 8;
+  options.maximumDataChunkSize = options.maximumDataChunkSize || -1;
   // This is outputColorType
   options.colorType =
     typeof options.colorType === "number"
@@ -122,6 +123,19 @@ Packer.prototype.packIHDR = function (width, height) {
 
 Packer.prototype.packIDAT = function (data) {
   return this._packChunk(constants.TYPE_IDAT, data);
+};
+
+Packer.prototype.packIDATs = function (data) {
+  if (this._options.maximumDataChunkSize === -1) {
+    return [this.packIDAT(data)];
+  }
+  let chunks = [];
+  let dataChunkAmount = Math.ceil(data.length / this._options.maximumDataChunkSize);
+  for (let i = 0; i < dataChunkAmount; i++) {
+    let startIndex = i * this._options.maximumDataChunkSize;
+    chunks.push(this.packIDAT(data.subarray(startIndex, Math.min(data.length, startIndex + this._options.maximumDataChunkSize))));
+  }
+  return chunks;
 };
 
 Packer.prototype.packIEND = function () {


### PR DESCRIPTION
This allows the data in the PNG to be split up over multiple DAT chunks. 

For my use case I used the option `maximumDataChunkSize: 32768`

```js
let outputBuffer = PNG.sync.write(fullPunksPNG, {deflateStrategy: 0, filterType: 0, maximumDataChunkSize: 32768});
```


**Motivation**
- I'm trying to recreate a PNG exactly how it was from pixel data. I noticed the exported PNG using pngjs had a single DAT chunk while the original file I try to recreate has multiple DAT chunks. With this fix I managed to make an exact replica of the original using the pixel data and the right compression settings.