### PR TITLE
feature-detect to always use native zlib if available

### DIFF
--- a/lib/parser-sync.js
+++ b/lib/parser-sync.js
@@ -2,7 +2,7 @@
 
 let hasSyncZlib = true;
 let zlib = require("zlib");
-let inflateSync = require("./sync-inflate");
+let inflateSync = zlib.inflateSync ?? require("./sync-inflate");
 if (!zlib.deflateSync) {
   hasSyncZlib = false;
 }
@@ -77,7 +77,7 @@ module.exports = function (buffer, options) {
 
   let inflatedData;
   if (metaData.interlace) {
-    inflatedData = zlib.inflateSync(inflateData);
+    inflatedData = inflateSync(inflateData);
   } else {
     let rowSize =
       ((metaData.width * metaData.bpp * metaData.depth + 7) >> 3) + 1;


### PR DESCRIPTION
line 85 is already calling the function we saved so a diff there wasn't necessary